### PR TITLE
feat: handle default value in twig extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ $param2 = $cat['param2'];
 Both of cases has an identical perfomance - the whole group will fetch while first access to it, fetching of data will 
 be only one time.
 
+#### Using default value in twig
+
+```twig
+{% extends '::base.html.twig'%}
+
+{% block meta %}
+<title>{{ settings('page_title', null, 'My default title') }}</title>
+<meta name="description" content="{{ settings('meta', 'description', 'My default description') }}">
+<meta name="keywords" content="{{ settings('meta', 'keywords', 'keywords1, keywords2') }}">
+{% endblock %}
+```
+
 #### Using groups in twig
 
 ```twig

--- a/Twig/SettingsExtension.php
+++ b/Twig/SettingsExtension.php
@@ -30,9 +30,9 @@ class SettingsExtension extends \Twig_Extension
         );
     }
 
-    public function getSettings($name, $subname = null)
+    public function getSettings($name, $subname = null, $default = null)
     {
-        return $this->settings->get($name, $subname);
+        return $this->settings->get($name, $subname, $default);
     }
 
     public function getSettingsGroup($name)


### PR DESCRIPTION
Hi,

You have developed a way to return a default value in `Settings` class but can't be used into the Twig Extension. This PR fix this.

Thanks.