### PR TITLE
Dependency injection compatibility + `settings`alias public by default

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,9 @@ services:
             - "@doctrine.orm.entity_manager"
             - "@lexxpavlov_settings.cache_provider"
 
+    Lexxpavlov\SettingsBundle\Service\Settings:
+        alias: lexxpavlov_settings.settings
+
     lexxpavlov_settings.twig.settings:
         class: Lexxpavlov\SettingsBundle\Twig\SettingsExtension
         arguments:

--- a/Resources/config/settings_service.yml
+++ b/Resources/config/settings_service.yml
@@ -1,3 +1,4 @@
 services:
     settings:
+        public: true
         alias: lexxpavlov_settings.settings


### PR DESCRIPTION
Actually, we can't inject the `settings` service this PR fix this.
Also, the `settings` alias isn't public by default since 3.4